### PR TITLE
fix: patch CVE picomatch/brace-expansion/serialize-javascript overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,5 +67,15 @@
     "typescript": "5.9.3",
     "vitest": "^4.1.0"
   },
-  "_buildTimestamp": "2026-03-17T10:55"
+  "_buildTimestamp": "2026-03-17T10:55",
+  "pnpm": {
+    "overrides": {
+      "picomatch": ">=4.0.4",
+      "brace-expansion": ">=2.0.3",
+      "serialize-javascript": ">=7.0.5",
+      "flatted": ">=3.4.2",
+      "minimatch": ">=10.2.3",
+      "ajv": ">=8.18.0"
+    }
+  }
 }


### PR DESCRIPTION
Adds `pnpm.overrides` entries to patch:
- CVE-2026-33671/33672 (picomatch HIGH/MEDIUM)
- CVE-2026-33750 (brace-expansion MEDIUM)
- CVE-2026-34043/GHSA-5c6j (serialize-javascript HIGH/MEDIUM)
- And other repo-specific CVEs

Fixes Dependabot alerts.