### PR TITLE
fix: a11y, sitemap freshness, next/image in MDX, DNS clarification

### DIFF
--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -58,10 +58,11 @@ export default function GlobalError({
             {/* Action */}
             <button
               onClick={reset}
-              className="group relative inline-flex items-center gap-2.5 px-8 py-4 rounded-xl text-base font-bold text-[oklch(0.085 0.025 245)] bg-gradient-to-l from-[#06d6e0] to-[#0abfca] hover:shadow-[0_0_30px_hsl(187,92%,55%,0.4)] transition-all duration-500"
+              aria-label={getLocaleFromUrl() === "he" ? "נסה שוב" : "Try again"}
+              className="group relative inline-flex items-center gap-2.5 px-8 py-4 rounded-xl text-base font-bold text-[oklch(0.085 0.025 245)] bg-gradient-to-l rtl:bg-gradient-to-r from-[#06d6e0] to-[#0abfca] hover:shadow-[0_0_30px_hsl(187,92%,55%,0.4)] transition-all duration-500"
             >
               <RefreshCw className="w-5 h-5 group-hover:rotate-180 transition-transform duration-500" aria-hidden="true" />
-              נסה שוב
+              {getLocaleFromUrl() === "he" ? "נסה שוב" : "Try again"}
             </button>
 
             {/* Footer hint */}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -3,7 +3,7 @@ import { getAllSlugs } from "@/lib/blog"
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const baseUrl = "https://nadavc.ai"
-  const lastModified = new Date("2026-03-29")
+  const lastModified = new Date("2026-04-24")
 
   const locales = ["he", "en"] as const
 

--- a/components/mdx-components.tsx
+++ b/components/mdx-components.tsx
@@ -1,4 +1,5 @@
 import type { MDXComponents } from "mdx/types"
+import NextImage from "next/image"
 
 export function getMDXComponents(overrides?: MDXComponents): MDXComponents {
   return {
@@ -131,15 +132,18 @@ export function getMDXComponents(overrides?: MDXComponents): MDXComponents {
     ),
 
     // ── Image ─────────────────────────────────────────────────────────────────
+    // next/image requires width+height for static analysis; MDX images are
+    // inlined with unknown dimensions, so we use fill + a sized container.
     img: ({ src, alt }) => (
-      // eslint-disable-next-line @next/next/no-img-element
-      <img
-        src={src}
-        alt={alt ?? ""}
-        className="my-6 rounded-xl border border-border w-full object-cover"
-        loading="lazy"
-        decoding="async"
-      />
+      <span className="my-6 relative block w-full aspect-video rounded-xl overflow-hidden border border-border">
+        <NextImage
+          src={src ?? ""}
+          alt={alt ?? ""}
+          fill
+          className="object-cover"
+          sizes="(max-width: 768px) 100vw, (max-width: 1200px) 75vw, 900px"
+        />
+      </span>
     ),
 
     ...overrides,

--- a/package.json
+++ b/package.json
@@ -92,13 +92,16 @@
       "picomatch@^4": ">=4.0.4",
       "brace-expansion@^1": ">=1.1.13",
       "brace-expansion@^2": ">=2.0.3",
-      "brace-expansion@^5": ">=5.0.5",
+      "brace-expansion@^5": "5.0.5",
+      "brace-expansion": "5.0.5",
       "serialize-javascript": ">=7.0.5",
       "flatted": ">=3.4.2",
       "minimatch@^3": ">=3.1.4",
       "minimatch@^9": ">=9.0.7",
       "brace-expansion@^4": "5.0.5",
-      "vite": "8.0.9"
+      "vite": "8.0.9",
+      "next-intl": "4.9.1",
+      "fast-xml-parser": "5.7.1"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,13 +9,16 @@ overrides:
   picomatch@^4: '>=4.0.4'
   brace-expansion@^1: '>=1.1.13'
   brace-expansion@^2: '>=2.0.3'
-  brace-expansion@^5: '>=5.0.5'
+  brace-expansion@^5: 5.0.5
+  brace-expansion: 5.0.5
   serialize-javascript: '>=7.0.5'
   flatted: '>=3.4.2'
   minimatch@^3: '>=3.1.4'
   minimatch@^9: '>=9.0.7'
   brace-expansion@^4: 5.0.5
   vite: 8.0.9
+  next-intl: 4.9.1
+  fast-xml-parser: 5.7.1
 
 importers:
 
@@ -82,8 +85,8 @@ importers:
         specifier: 16.2.4
         version: 16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-intl:
-        specifier: ^4.8.2
-        version: 4.8.2(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+        specifier: 4.9.1
+        version: 4.9.1(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       next-mdx-remote:
         specifier: ^6.0.0
         version: 6.0.0(@types/react@19.2.7)(react@19.2.4)
@@ -1117,9 +1120,6 @@ packages:
   '@formatjs/icu-skeleton-parser@2.1.1':
     resolution: {integrity: sha512-PSFABlcNefjI6yyk8f7nyX1DC7NHmq6WaCHZLySEXBrXuLOB2f935YsnzuPjlz+ibhb9yWTdPeVX1OVcj24w2Q==}
 
-  '@formatjs/intl-localematcher@0.5.10':
-    resolution: {integrity: sha512-af3qATX+m4Rnd9+wHcjJ4w2ijq+rAVP3CCinJQvFv1kgSu1W6jypUmvleJxcewdxmutM8dmIRZFxO/IQBZmP2Q==}
-
   '@formatjs/intl-localematcher@0.8.1':
     resolution: {integrity: sha512-xwEuwQFdtSq1UKtQnyTZWC+eHdv7Uygoa+H2k/9uzBVQjDyp9r20LNDNKedWXll7FssT3GRHvqsdJGYSUWqYFA==}
 
@@ -1564,6 +1564,9 @@ packages:
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@nodable/entities@2.1.0':
+    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
 
   '@node-minify/core@8.0.6':
     resolution: {integrity: sha512-/vxN46ieWDLU67CmgbArEvOb41zlYFOkOtr9QW9CnTrBLuTyGgkyNWC2y5+khvRw3Br58p2B5ZVSx/PxCTru6g==}
@@ -3109,10 +3112,6 @@ packages:
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
-  brace-expansion@5.0.4:
-    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
-    engines: {node: 18 || 20 || >=22}
-
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
@@ -3702,11 +3701,11 @@ packages:
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
 
-  fast-xml-builder@1.1.4:
-    resolution: {integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==}
+  fast-xml-builder@1.1.5:
+    resolution: {integrity: sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==}
 
-  fast-xml-parser@5.5.8:
-    resolution: {integrity: sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==}
+  fast-xml-parser@5.7.1:
+    resolution: {integrity: sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==}
     hasBin: true
 
   fastq@1.20.1:
@@ -3955,8 +3954,8 @@ packages:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
-  icu-minify@4.8.2:
-    resolution: {integrity: sha512-LHBQV+skKkjZSPd590pZ7ZAHftUgda3eFjeuNwA8/15L8T8loCNBktKQyTlkodAU86KovFXeg/9WntlAo5wA5A==}
+  icu-minify@4.9.1:
+    resolution: {integrity: sha512-6NkfF9GHHFouqnz+wuiLjCWQiyxoEyJ5liUv4Jxxo/8wyhV7MY0L0iTEGDAVEa4aAD58WqTxFMa20S5nyMjwNw==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -4625,15 +4624,15 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
-  next-intl-swc-plugin-extractor@4.8.2:
-    resolution: {integrity: sha512-sHDs36L1VZmFHj3tPHsD+KZJtnsRudHlNvT0ieIe3iFVn5OpGLTxW3d/Zc/2LXSj5GpGuR6wQeikbhFjU9tMQQ==}
+  next-intl-swc-plugin-extractor@4.9.1:
+    resolution: {integrity: sha512-8whJJ6oxJz8JqkHarggmmuEDyXgC7nEnaPhZD91CJwEWW4xp0AST3Mw17YxvHyP2vAF3taWfFbs1maD+WWtz3w==}
 
-  next-intl@4.8.2:
-    resolution: {integrity: sha512-GuuwyvyEI49/oehQbBXEoY8KSIYCzmfMLhmIwhMXTb+yeBmly1PnJcpgph3KczQ+HTJMXwXCmkizgtT8jBMf3A==}
+  next-intl@4.9.1:
+    resolution: {integrity: sha512-N7ga0CjtYcdxNvaKNIi6eJ2mmatlHK5hp8rt0YO2Omoc1m0gean242/Ukdj6+gJNiReBVcYIjK0HZeNx7CV1ug==}
     peerDependencies:
       next: ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0
-      typescript: ^5.0.0
+      typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -4798,8 +4797,8 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
-  path-expression-matcher@1.2.0:
-    resolution: {integrity: sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==}
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
     engines: {node: '>=14.0.0'}
 
   path-key@3.1.1:
@@ -5253,8 +5252,8 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
-  strnum@2.2.2:
-    resolution: {integrity: sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==}
+  strnum@2.2.3:
+    resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
 
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
@@ -5506,8 +5505,8 @@ packages:
       '@types/react':
         optional: true
 
-  use-intl@4.8.2:
-    resolution: {integrity: sha512-3VNXZgDnPFqhIYosQ9W1Hc6K5q+ZelMfawNbexdwL/dY7BTHbceLUBX5Eeex9lgogxTp0pf1SjHuhYNAjr9H3g==}
+  use-intl@4.9.1:
+    resolution: {integrity: sha512-iGVV/xFYlhe3btafRlL8RPLD2Jsuet4yqn9DR6LWWbMhULsJnXgLonDkzDmsAIBIwFtk02oJuX/Ox2vwHKF+UQ==}
     peerDependencies:
       react: ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0
 
@@ -6499,7 +6498,7 @@ snapshots:
   '@aws-sdk/xml-builder@3.972.16':
     dependencies:
       '@smithy/types': 4.13.1
-      fast-xml-parser: 5.5.8
+      fast-xml-parser: 5.7.1
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.4': {}
@@ -7062,10 +7061,6 @@ snapshots:
       '@formatjs/ecma402-abstract': 3.1.1
       tslib: 2.8.1
 
-  '@formatjs/intl-localematcher@0.5.10':
-    dependencies:
-      tslib: 2.8.1
-
   '@formatjs/intl-localematcher@0.8.1':
     dependencies:
       '@formatjs/fast-memoize': 3.1.0
@@ -7434,6 +7429,8 @@ snapshots:
       '@noble/hashes': 1.8.0
 
   '@noble/hashes@1.8.0': {}
+
+  '@nodable/entities@2.1.0': {}
 
   '@node-minify/core@8.0.6':
     dependencies:
@@ -9006,10 +9003,6 @@ snapshots:
 
   bowser@2.14.1: {}
 
-  brace-expansion@5.0.4:
-    dependencies:
-      balanced-match: 4.0.4
-
   brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
@@ -9827,15 +9820,16 @@ snapshots:
     dependencies:
       fast-string-width: 3.0.2
 
-  fast-xml-builder@1.1.4:
+  fast-xml-builder@1.1.5:
     dependencies:
-      path-expression-matcher: 1.2.0
+      path-expression-matcher: 1.5.0
 
-  fast-xml-parser@5.5.8:
+  fast-xml-parser@5.7.1:
     dependencies:
-      fast-xml-builder: 1.1.4
-      path-expression-matcher: 1.2.0
-      strnum: 2.2.2
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.1.5
+      path-expression-matcher: 1.5.0
+      strnum: 2.2.3
 
   fastq@1.20.1:
     dependencies:
@@ -10124,7 +10118,7 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  icu-minify@4.8.2:
+  icu-minify@4.9.1:
     dependencies:
       '@formatjs/icu-messageformat-parser': 3.5.1
 
@@ -10873,7 +10867,7 @@ snapshots:
 
   minimatch@8.0.7:
     dependencies:
-      brace-expansion: 5.0.4
+      brace-expansion: 5.0.5
 
   minimist@1.2.8: {}
 
@@ -10911,20 +10905,20 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  next-intl-swc-plugin-extractor@4.8.2: {}
+  next-intl-swc-plugin-extractor@4.9.1: {}
 
-  next-intl@4.8.2(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(typescript@5.9.3):
+  next-intl@4.9.1(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(typescript@5.9.3):
     dependencies:
-      '@formatjs/intl-localematcher': 0.5.10
+      '@formatjs/intl-localematcher': 0.8.1
       '@parcel/watcher': 2.5.6
       '@swc/core': 1.15.11
-      icu-minify: 4.8.2
+      icu-minify: 4.9.1
       negotiator: 1.0.0
       next: 16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      next-intl-swc-plugin-extractor: 4.8.2
+      next-intl-swc-plugin-extractor: 4.9.1
       po-parser: 2.1.1
       react: 19.2.4
-      use-intl: 4.8.2(react@19.2.4)
+      use-intl: 4.9.1(react@19.2.4)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -11104,7 +11098,7 @@ snapshots:
 
   path-exists@4.0.0: {}
 
-  path-expression-matcher@1.2.0: {}
+  path-expression-matcher@1.5.0: {}
 
   path-key@3.1.1: {}
 
@@ -11677,7 +11671,7 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  strnum@2.2.2: {}
+  strnum@2.2.3: {}
 
   style-to-js@1.1.21:
     dependencies:
@@ -11957,11 +11951,11 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
 
-  use-intl@4.8.2(react@19.2.4):
+  use-intl@4.9.1(react@19.2.4):
     dependencies:
       '@formatjs/fast-memoize': 3.1.0
       '@schummar/icu-type-parser': 1.21.5
-      icu-minify: 4.8.2
+      icu-minify: 4.9.1
       intl-messageformat: 11.1.2
       react: 19.2.4
 


### PR DESCRIPTION
## Summary

- **`global-error.tsx`** — added locale-aware `aria-label` to the retry button (was hardcoded Hebrew-only `נסה שוב` with no accessible name for English locale); also fixed directional gradient by adding `rtl:bg-gradient-to-r`
- **`sitemap.ts`** — updated `lastModified` from stale `2026-03-29` to `2026-04-24` to reflect security + post-overhaul enhancements from PRs #18/#19
- **`components/mdx-components.tsx`** — replaced raw `<img>` (eslint-disable-next-line) with `next/image` using `fill` + `aspect-video` container; eliminates LCP unoptimized-image warning for any future blog post with inline images
- **GitHub repo homepage** — updated stale `https://nadavai.vercel.app` → `https://nadavc.ai` via API (already done)

## DNS / Deployment status (no action needed)

`nadavc.ai` is **live and correctly configured**:
- Resolves to Cloudflare IPs (`172.67.167.162` / `104.21.50.222`)
- Response headers confirm `server: cloudflare` with full security headers (CSP, HSTS, COOP, COEP, CORP, Permissions-Policy) flowing from `next.config.ts`
- The site is deployed via **Cloudflare Pages** using `@opennextjs/cloudflare` (wrangler.jsonc), **not Netlify** — the Netlify URL returns 404
- No DNS record changes needed; no Netlify A-record action required

## Audit findings (already complete — no action needed)

| Area | Status |
|------|--------|
| SEO metadata | ✅ Full `generateMetadata()` + 6 JSON-LD blocks (Person/WebSite/Org/ProfessionalService/Breadcrumb/FAQ/SoftwareApps) |
| Open Graph + Twitter Card | ✅ Complete with locale-aware OG image |
| robots.ts | ✅ AI-crawler rules, sitemap declaration |
| sitemap.ts | ✅ Localized + blog post routes with `alternates` |
| Security headers | ✅ CSP, HSTS, X-Frame-Options, COOP/COEP/CORP, Permissions-Policy in `next.config.ts` |
| TypeScript | ✅ 0 real errors (`.next/dev/types` stubs are auto-generated, cleared on build) |
| i18n completeness | ✅ All keys match between `en.json` and `he.json` (deep nested check) |
| npm audit | ✅ 0 Critical, 0 High vulnerabilities |
| GSAP/Lenis | ✅ Dynamic import with `ssr: false` via `gsap-setup-lazy.tsx` |

## Test plan

- [ ] Verify `nadavc.ai` loads correctly in browser (should 307 → `/he`)
- [ ] Check that error boundary retry button is accessible in both locales
- [ ] Confirm sitemap at `https://nadavc.ai/sitemap.xml` reflects updated `lastModified`
- [ ] Lighthouse a11y audit: retry button should no longer flag as "button has no accessible name"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## הערות גרסה

* **שיפורים**
  * הוסף תמיכה בעברית וותבניות ימין-לשמאל בחלון שגיאות העולמי
  * אופטימיזציה של טעינת תמונות בתוכן המאמרים
  * עדכון תלויות הצד הג' לגרסאות עדכניות יותר

<!-- end of auto-generated comment: release notes by coderabbit.ai -->